### PR TITLE
Update Migration contract to Solidity 0.4.23

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,15 +1,15 @@
-pragma solidity ^0.4.17;
+pragma solidity ^0.4.23;
 
 contract Migrations {
   address public owner;
   uint public last_completed_migration;
 
-  modifier restricted() {
-    if (msg.sender == owner) _;
+  constructor() public {
+    owner = msg.sender;
   }
 
-  function Migrations() public {
-    owner = msg.sender;
+  modifier restricted() {
+    if (msg.sender == owner) _;
   }
 
   function setCompleted(uint completed) public restricted {


### PR DESCRIPTION
I updated the Solidity contract for the Migration to use the current version of Solidity. Since the old constructor is depreciated, I figured it would be better to get rid of that and show the example for when people `truffle init`.