### PR TITLE
Add wallet provider usage notes

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,3 +1,17 @@
+/*
+ * NB: since truffle-hdwallet-provider 0.0.5 you must wrap HDWallet providers in a 
+ * function when declaring them. Failure to do so will cause commands to hang. ex:
+ * ```
+ * mainnet: {
+ *     provider: function() { 
+ *       return new HDWalletProvider(mnemonic, 'https://mainnet.infura.io/<infura-key>') 
+ *     },
+ *     network_id: '1',
+ *     gas: 4500000,
+ *     gasPrice: 10000000000,
+ *   },
+ */
+
 module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>
   // to customize your Truffle configuration!

--- a/truffle.js
+++ b/truffle.js
@@ -1,3 +1,17 @@
+/*
+ * NB: since truffle-hdwallet-provider 0.0.5 you must wrap HDWallet providers in a 
+ * function when declaring them. Failure to do so will cause commands to hang. ex:
+ * ```
+ * mainnet: {
+ *     provider: function() { 
+ *       return new HDWalletProvider(mnemonic, 'https://mainnet.infura.io/<infura-key>') 
+ *     },
+ *     network_id: '1',
+ *     gas: 4500000,
+ *     gasPrice: 10000000000,
+ *   },
+ */
+
 module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>
   // to customize your Truffle configuration!


### PR DESCRIPTION
Failure to wrap providers in a function is causing commands to hang on exit since a recent upgrade to HDWallet. This adds a warning to the config boilerplate. 

See [truffle 1022](https://github.com/trufflesuite/truffle/issues/1022)