### PR TITLE
Remove the readme from the box config ignore property

### DIFF
--- a/truffle-box.json
+++ b/truffle-box.json
@@ -1,6 +1,5 @@
 {
   "ignore": [
-    "README.md",
     "test/.gitkeep"
   ],
   "commands": {


### PR DESCRIPTION
Including README.js in the ignore section of the box config causes it to get deleted from the projects directory at the end of the unboxing/initing process.