### PR TITLE
Fix import dependency variable name

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -18,7 +18,7 @@
  *
  */
 
-// const HDWallet = require('truffle-hdwallet-provider');
+// const HDWalletProvider = require('truffle-hdwallet-provider');
 // const infuraKey = "fj4jll3k.....";
 //
 // const fs = require('fs');


### PR DESCRIPTION
Hello,

I renamed *HDWallet* to *HDWalletProvider* on import to match with the variable names used below.
It's very obvious to developers familiarized but might not be for new developers.